### PR TITLE
Changing call to xplot to plot1d

### DIFF
--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -411,7 +411,7 @@ def simple_calib(slf, det, get_poly=False):
             if msgs._debug['arc']:
                 msgs.warn('You should probably try your best to ID lines now.')
                 debugger.set_trace()
-                debugger.xplot(yprep)
+                debugger.plot1d(yprep)
             else:
                 msgs.error('Insufficient lines to auto-fit.')
 


### PR DESCRIPTION
File ardebug.py has no module xplot. This function call probably just slipped through the cracks.